### PR TITLE
Use compliance session token instead

### DIFF
--- a/android/src/main/java/com/reactnativefacetec/FacetecModule.java
+++ b/android/src/main/java/com/reactnativefacetec/FacetecModule.java
@@ -99,10 +99,14 @@ public class FacetecModule extends ReactContextBaseJavaModule {
   }
 
     @ReactMethod
-    public void LivenessCheck(Callback onSuccess, Callback onFail) {
+    public void LivenessCheck(String, sessionToken, Callback onSuccess, Callback onFail) {
         this.onSuccess = onSuccess;
         this.onFail = onFail;
-        latestProcessor = new LivenessCheckProcessor( getCurrentActivity(), sessionTokenErrorCallback, sessionTokenSuccessCallback);
+
+        Log.d("ZoomSDK", "Do livenesss check token" + sessionToken);
+        Log.d("ZoomSDK", "Do livenesss check onSuccess" + onSuccess);
+        Log.d("ZoomSDK", "Do livenesss check onFail" + onFail);
+        // latestProcessor = new LivenessCheckProcessor( getCurrentActivity(), sessionToken, sessionTokenErrorCallback, sessionTokenSuccessCallback);
     }
 
     @ReactMethod

--- a/android/src/main/java/com/reactnativefacetec/FacetecModule.java
+++ b/android/src/main/java/com/reactnativefacetec/FacetecModule.java
@@ -103,10 +103,7 @@ public class FacetecModule extends ReactContextBaseJavaModule {
         this.onSuccess = onSuccess;
         this.onFail = onFail;
 
-        Log.d("ZoomSDK", "Do livenesss check token" + sessionToken);
-        Log.d("ZoomSDK", "Do livenesss check onSuccess" + onSuccess);
-        Log.d("ZoomSDK", "Do livenesss check onFail" + onFail);
-        // latestProcessor = new LivenessCheckProcessor( getCurrentActivity(), sessionToken, sessionTokenErrorCallback, sessionTokenSuccessCallback);
+        latestProcessor = new LivenessCheckProcessor( getCurrentActivity(), sessionToken, sessionTokenErrorCallback, sessionTokenSuccessCallback);
     }
 
     @ReactMethod

--- a/android/src/main/java/com/reactnativefacetec/FacetecModule.java
+++ b/android/src/main/java/com/reactnativefacetec/FacetecModule.java
@@ -99,7 +99,7 @@ public class FacetecModule extends ReactContextBaseJavaModule {
   }
 
     @ReactMethod
-    public void LivenessCheck(String, sessionToken, Callback onSuccess, Callback onFail) {
+    public void LivenessCheck(String sessionToken, Callback onSuccess, Callback onFail) {
         this.onSuccess = onSuccess;
         this.onFail = onFail;
 

--- a/android/src/main/java/com/reactnativefacetec/ZoomProcessors/LivenessCheckProcessor.java
+++ b/android/src/main/java/com/reactnativefacetec/ZoomProcessors/LivenessCheckProcessor.java
@@ -29,21 +29,25 @@ public class LivenessCheckProcessor extends Processor implements ZoomFaceMapProc
     SessionTokenErrorCallback sessionTokenErrorCallback;
     private boolean _isSuccess = false;
 
-    public LivenessCheckProcessor(final Context context, final SessionTokenErrorCallback sessionTokenErrorCallback, SessionTokenSuccessCallback sessionTokenSuccessCallback) {
+    public LivenessCheckProcessor(final Context context, String sessionToken, final SessionTokenErrorCallback sessionTokenErrorCallback, SessionTokenSuccessCallback sessionTokenSuccessCallback) {
         this.sessionTokenSuccessCallback = sessionTokenSuccessCallback;
         this.sessionTokenErrorCallback = sessionTokenErrorCallback;
-        NetworkingHelpers.getSessionToken(new NetworkingHelpers.SessionTokenCallback() {
-            @Override
-            public void onResponse(String sessionToken) {
-                // Launch the ZoOm Session.
-                ZoomSessionActivity.createAndLaunchZoomSession(context, LivenessCheckProcessor.this, sessionToken);
-            }
 
-            @Override
-            public void onError() {
-                sessionTokenErrorCallback.onError("LivenessCheckProcessor");
-            }
-        });
+        // Launch the ZoOm Session.
+        ZoomSessionActivity.createAndLaunchZoomSession(context, LivenessCheckProcessor.this, sessionToken);
+
+        // NetworkingHelpers.getSessionToken(new NetworkingHelpers.SessionTokenCallback() {
+        //     @Override
+        //     public void onResponse(String sessionToken) {
+        //         // Launch the ZoOm Session.
+        //         ZoomSessionActivity.createAndLaunchZoomSession(context, LivenessCheckProcessor.this, sessionToken);
+        //     }
+
+        //     @Override
+        //     public void onError() {
+        //         sessionTokenErrorCallback.onError("LivenessCheckProcessor");
+        //     }
+        // });
     }
 
     public boolean isSuccess() {

--- a/android/src/main/java/com/reactnativefacetec/ZoomProcessors/LivenessCheckProcessor.java
+++ b/android/src/main/java/com/reactnativefacetec/ZoomProcessors/LivenessCheckProcessor.java
@@ -35,19 +35,6 @@ public class LivenessCheckProcessor extends Processor implements ZoomFaceMapProc
 
         // Launch the ZoOm Session.
         ZoomSessionActivity.createAndLaunchZoomSession(context, LivenessCheckProcessor.this, sessionToken);
-
-        // NetworkingHelpers.getSessionToken(new NetworkingHelpers.SessionTokenCallback() {
-        //     @Override
-        //     public void onResponse(String sessionToken) {
-        //         // Launch the ZoOm Session.
-        //         ZoomSessionActivity.createAndLaunchZoomSession(context, LivenessCheckProcessor.this, sessionToken);
-        //     }
-
-        //     @Override
-        //     public void onError() {
-        //         sessionTokenErrorCallback.onError("LivenessCheckProcessor");
-        //     }
-        // });
     }
 
     public boolean isSuccess() {

--- a/android/src/main/java/com/reactnativefacetec/ZoomProcessors/ZoomGlobalState.java
+++ b/android/src/main/java/com/reactnativefacetec/ZoomProcessors/ZoomGlobalState.java
@@ -12,7 +12,7 @@ public class ZoomGlobalState {
     public static String ZoomServerBaseURL = "https://api.zoomauth.com/api/v2/biometrics";
 
         // Chipper Compliance Service URL
-    public static String ChipperComplianceServiceBaseURL = "https://compliance-staging.herokuapp.com";
+    public static String ChipperComplianceServiceBaseURL = "https://compliance-production.herokuapp.com";
 
     // The customer-controlled public key used during encryption of FaceMap data.
     // Please see https://dev.zoomlogin.com/zoomsdk/#/licensing-and-encryption-keys for more information.

--- a/android/src/main/java/com/reactnativefacetec/ZoomProcessors/ZoomGlobalState.java
+++ b/android/src/main/java/com/reactnativefacetec/ZoomProcessors/ZoomGlobalState.java
@@ -12,7 +12,7 @@ public class ZoomGlobalState {
     public static String ZoomServerBaseURL = "https://api.zoomauth.com/api/v2/biometrics";
 
         // Chipper Compliance Service URL
-    public static String ChipperComplianceServiceBaseURL = "https://compliance-production.herokuapp.com";
+    public static String ChipperComplianceServiceBaseURL = "https://compliance-staging.herokuapp.com";
 
     // The customer-controlled public key used during encryption of FaceMap data.
     // Please see https://dev.zoomlogin.com/zoomsdk/#/licensing-and-encryption-keys for more information.

--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,8 @@ export function init(licenseText, onSuccess, onFail) {
   Facetec.Init(licenseText, onSuccess, onFail);
 }
 
-export function livenessCheck(onSuccess, onFail) {
-  Facetec.LivenessCheck(onSuccess, onFail);
+export function livenessCheck(sessionToken, onSuccess, onFail) {
+  Facetec.LivenessCheck(sessionToken, onSuccess, onFail);
 }
 
 export function updateLoadingUI(success) {


### PR DESCRIPTION
This update changes the implementation to use the session token sent from JS land to initiate the liveness check flow.