### PR TITLE
Catch UpdateLoadingUI Crash

### DIFF
--- a/android/src/main/java/com/reactnativefacetec/FacetecModule.java
+++ b/android/src/main/java/com/reactnativefacetec/FacetecModule.java
@@ -107,8 +107,12 @@ public class FacetecModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void UpdateLoadingUI(boolean success) {
-        latestProcessor.updateLoadingUI(success);
+    public void UpdateLoadingUI(boolean success, Callback onFail) {
+        try {
+            latestProcessor.updateLoadingUI(success);
+        } catch(Exception e){
+            onFail.invoke(e.getMessage());
+        }
     }
 
     Processor.SessionTokenErrorCallback sessionTokenErrorCallback = new Processor.SessionTokenErrorCallback() {

--- a/android/src/main/java/com/reactnativefacetec/ZoomProcessors/LivenessCheckProcessor.java
+++ b/android/src/main/java/com/reactnativefacetec/ZoomProcessors/LivenessCheckProcessor.java
@@ -43,12 +43,16 @@ public class LivenessCheckProcessor extends Processor implements ZoomFaceMapProc
 
     // Update zoom loading UI to either success or failed
     public void updateLoadingUI(final boolean success) {
-        if (success) {
-            ZoomCustomization.overrideResultScreenSuccessMessage = "Liveness\nConfirmed";
-            this.zoomFaceMapResultCallback.succeed();
-        } else {
-            this.zoomFaceMapResultCallback.retry();
-        }
+      try {
+          if (success) {
+              ZoomCustomization.overrideResultScreenSuccessMessage = "Liveness\nConfirmed";
+              this.zoomFaceMapResultCallback.succeed();
+          } else {
+              this.zoomFaceMapResultCallback.retry();
+          }
+      } catch(Exception e) {
+          throw e;
+      }
     }
 
     // Required function that handles calling ZoOm Server to get result and decides how to continue.

--- a/src/index.js
+++ b/src/index.js
@@ -9,8 +9,8 @@ export function livenessCheck(sessionToken, onSuccess, onFail) {
   Facetec.LivenessCheck(sessionToken, onSuccess, onFail);
 }
 
-export function updateLoadingUI(success) {
-  Facetec.UpdateLoadingUI(success);
+export function updateLoadingUI(success, onFail) {
+  Facetec.UpdateLoadingUI(success, onFail);
 }
 
 export default {


### PR DESCRIPTION
- This PR add a catch for `UpdateLoadingUI` in case it fails and calls the `onFail` callback to notify the Javascript client of the error. 
- If this does error the SDK will now sit for around 60 seconds where it then times out.
- This branch has been published. 

More details in [here](https://www.notion.so/chippercash/Facetec-null-object-reference-e9ea76556d124076a209353cbf962e1f).